### PR TITLE
Properly parse hostname from metadata

### DIFF
--- a/datasource/metadata/ec2/metadata.go
+++ b/datasource/metadata/ec2/metadata.go
@@ -78,7 +78,11 @@ func (ms metadataService) FetchMetadata() (datasource.Metadata, error) {
 	}
 
 	if hostname, err := ms.fetchAttribute(fmt.Sprintf("%s/hostname", ms.MetadataUrl())); err == nil {
-		metadata.Hostname = strings.Split(hostname, " ")[0]
+		hostname := strings.Split(hostname, ".")[0]
+		if len(hostname) > 63 {
+			hostname = hostname[:63]
+		}
+		metadata.Hostname = hostname
 	} else if _, ok := err.(pkg.ErrNotFound); !ok {
 		return metadata, err
 	}

--- a/datasource/metadata/ec2/metadata.go
+++ b/datasource/metadata/ec2/metadata.go
@@ -80,6 +80,7 @@ func (ms metadataService) FetchMetadata() (datasource.Metadata, error) {
 	if hostname, err := ms.fetchAttribute(fmt.Sprintf("%s/hostname", ms.MetadataUrl())); err == nil {
 		hostname := strings.Split(hostname, ".")[0]
 		if len(hostname) > 63 {
+			log.Printf("Truncating hostname %s to 63 bytes (%s)", hostname, hostname[:63])
 			hostname = hostname[:63]
 		}
 		metadata.Hostname = hostname

--- a/datasource/metadata/ec2/metadata_test.go
+++ b/datasource/metadata/ec2/metadata_test.go
@@ -180,7 +180,7 @@ func TestFetchMetadata(t *testing.T) {
 			root:         "/",
 			metadataPath: "2009-04-04/meta-data",
 			resources: map[string]string{
-				"/2009-04-04/meta-data/hostname":                  "host domain another_domain",
+				"/2009-04-04/meta-data/hostname":                  "host.local",
 				"/2009-04-04/meta-data/local-ipv4":                "1.2.3.4",
 				"/2009-04-04/meta-data/public-ipv4":               "5.6.7.8",
 				"/2009-04-04/meta-data/public-keys":               "0=test1\n",
@@ -189,6 +189,24 @@ func TestFetchMetadata(t *testing.T) {
 			},
 			expect: datasource.Metadata{
 				Hostname:      "host",
+				PrivateIPv4:   net.ParseIP("1.2.3.4"),
+				PublicIPv4:    net.ParseIP("5.6.7.8"),
+				SSHPublicKeys: map[string]string{"test1": "key"},
+			},
+		},
+		{
+			root:         "/",
+			metadataPath: "2009-04-04/meta-data",
+			resources: map[string]string{
+				"/2009-04-04/meta-data/hostname":                  "this-hostname-is-larger-than-sixty-three-characters-long-and-will-be-truncated.local",
+				"/2009-04-04/meta-data/local-ipv4":                "1.2.3.4",
+				"/2009-04-04/meta-data/public-ipv4":               "5.6.7.8",
+				"/2009-04-04/meta-data/public-keys":               "0=test1\n",
+				"/2009-04-04/meta-data/public-keys/0":             "openssh-key",
+				"/2009-04-04/meta-data/public-keys/0/openssh-key": "key",
+			},
+			expect: datasource.Metadata{
+				Hostname:      "this-hostname-is-larger-than-sixty-three-characters-long-and-wi",
 				PrivateIPv4:   net.ParseIP("1.2.3.4"),
 				PublicIPv4:    net.ParseIP("5.6.7.8"),
 				SSHPublicKeys: map[string]string{"test1": "key"},


### PR DESCRIPTION
# Properly parse hostname from metadata

This change splits the hostname supplied by the metadata service using dot as a delimiter instead of a single space. This API should return a single FQDN on most clouds.

Sample output from fetching the hostname from the AWS metadata service can be seen here:

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html

OpenStack has the same kind of output.

We also make sure that the resulting hostname is no longer than 63 characters long.

This will ensure that ```/etc/hostname``` will contain a proper short form hostname instead of a FQDN.

## How to use

Build and then run:

```bash
./coreos-cloudinit --oem=ec2-compat
```

on any VM spun up on a cloud with an ec2 compatible metadata service.

## Testing done

Build a flatcar image using this commit and spun up a k8s cluster using kops. Hostname was properly set to the short form, not the FQDN.

Addresses the following issue: https://github.com/kubernetes/kops/issues/15385

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

