### PR TITLE
units: Don't use configdrive on DigitalOcean

### DIFF
--- a/units/user-configdrive.service
+++ b/units/user-configdrive.service
@@ -15,6 +15,10 @@ Before=user-config.target
 # until after the systemd dbus calls are made non-blocking.
 After=enable-oem-cloudinit.service oem-cloudinit.service
 
+# Skip on clouds that are covered by flatcar/init:systemd/system/oem-cloudinit.service
+ConditionKernelCommandLine=!flatcar.oem.id=digitalocean
+ConditionKernelCommandLine=!coreos.oem.id=digitalocean
+
 [Service]
 Type=oneshot
 TimeoutSec=10min

--- a/units/user-configdrive.service
+++ b/units/user-configdrive.service
@@ -13,7 +13,7 @@ Before=user-config.target
 # systemd knows about the ordering as early as possible.
 # coreos-cloudinit could implement a simple lock but that cannot be used
 # until after the systemd dbus calls are made non-blocking.
-After=oem-cloudinit.service
+After=enable-oem-cloudinit.service oem-cloudinit.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
For DigitalOcean we have the oem-cloudinit service and if the
    configdrive gets used in addition, it will process the metadata
    unconditionally and set the hostname even if afterburn already prepared
    the hostname and Ignition maybe overwrote it with a static value.
    Don't use the configdrive trigger at all on DigitalOcean because both
    the metadata is covered by afterburn and if cloudinit userdata is found,
    oem-cloudinit will run.

I added another change where we forgot to align the condition with the changed way `oem-cloudinit` gets started:
- user-configdrive: Restore ordering with configdrive cloudinit
    
    Since we don't enable the oem cloudinit service from the initrd but from
    the real system, add an additional ordering for the service that enables
    the oem cloudinit service.
    We could also move the cloudinit enablement back to the initrd to avoid
    this race but maybe this here is enough.

## How to use

Should fix the Alpha test failure for DigitalOcean.

We might also want to skip the configdrive processing if Ignition ran but since our qemu script relies on that for ssh key injection, we first need to port it.

## Testing done

