### PR TITLE
units: Workaround for user-configvirtfs.service

### DIFF
--- a/units/media-configvirtfs.mount
+++ b/units/media-configvirtfs.mount
@@ -1,5 +1,5 @@
 [Unit]
-Wants=user-configvirtfs.service
+Upholds=user-configvirtfs.service
 Before=user-configvirtfs.service
 # Only mount config drive block devices automatically in virtual machines
 # or any host that has it explicitly enabled and not explicitly disabled.


### PR DESCRIPTION
As Jeremi noticed with the current Flatcar Stable 3510.2.7 and a custom Docker brought in as systemd-sysext image, the qemu VM didn't pick up the SSH keys anymore. This couldn't be reproduced with Alpha, though. The culprit is not completely known but it seems to be a race condition that makes the Wants= dependency of media-configvirtfs.mount not take action.
To work around the problem, use Upholds= which eventually starts user-configvirtfs.service.

## How to use

Backport to Stable

## Testing done
With the change as drop-in, one can login via SSH:
```
variant: flatcar
version: 1.0.0
storage:
  files:
    - path: /opt/extensions/docker/docker-24.0.5-x86-64.raw
      contents:
        source: https://github.com/flatcar/sysext-bakery/releases/download/20230901/docker-24.0.5-x86-64.raw
    - path: /etc/systemd/system-generators/torcx-generator
    - path: /etc/sysupdate.d/noop.conf
      contents:
        source: https://github.com/flatcar/sysext-bakery/releases/download/20230901/noop.conf
    - path: /etc/sysupdate.docker.d/docker.conf
      contents:
        source: https://github.com/flatcar/sysext-bakery/releases/download/20230901/docker.conf
  links:
    - target: /opt/extensions/docker/docker-24.0.5-x86-64.raw
      path: /etc/extensions/docker.raw
      hard: false
    - path: /etc/extensions/docker-flatcar.raw
      target: /dev/null
      overwrite: true
    - path: /etc/extensions/containerd-flatcar.raw
      target: /dev/null
      overwrite: true
systemd:
  units:
    - name: systemd-sysupdate.timer
      enabled: true
    - name: systemd-sysupdate.service
      dropins:
        - name: docker.conf
          contents: |
            [Service]
            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C docker update
        - name: sysext.conf
          contents: |
            [Service]
            ExecStartPost=systemctl restart systemd-sysext
    - name: media-configvirtfs.mount
      dropins:
        - name: upholds.conf
          contents: |
            [Unit]
            Upholds=user-configvirtfs.service
```