### PR TITLE
Skip coreos-cloudinit if ignition is used

### DIFF
--- a/units/user-configdrive.service
+++ b/units/user-configdrive.service
@@ -21,6 +21,7 @@ ConditionKernelCommandLine=!coreos.oem.id=digitalocean
 
 [Service]
 Type=oneshot
+ExecCondition=/usr/bin/bash -c "if [ -f '/etc/.ignition-result.json' ] && /usr/bin/jq -e '.userConfigProvided == true' /etc/.ignition-result.json; then exit 1; fi"
 TimeoutSec=10min
 RemainAfterExit=yes
 EnvironmentFile=-/etc/environment

--- a/units/user-configdrive.service
+++ b/units/user-configdrive.service
@@ -18,7 +18,8 @@ After=enable-oem-cloudinit.service oem-cloudinit.service
 # Skip on clouds that are covered by flatcar/init:systemd/system/oem-cloudinit.service
 ConditionKernelCommandLine=!flatcar.oem.id=digitalocean
 ConditionKernelCommandLine=!coreos.oem.id=digitalocean
-
+ConditionKernelCommandLine=!coreos.oem.id=openstack
+ConditionKernelCommandLine=!flatcar.oem.id=openstack
 [Service]
 Type=oneshot
 ExecCondition=/usr/bin/bash -c "if [ -f '/etc/.ignition-result.json' ] && /usr/bin/jq -e '.userConfigProvided == true' /etc/.ignition-result.json; then exit 1; fi"


### PR DESCRIPTION
This change skips coreos-cloudinit when config drive is used, if the system was configured using ignition.

Building an image with this change now. Will report back once I manage to test it.

Addresses behavior seen in:
  * https://github.com/flatcar/Flatcar/issues/1385