### PR TITLE
FIX: adjust packet metadata url and apiVersion for new equinix api

### DIFF
--- a/datasource/metadata/packet/metadata.go
+++ b/datasource/metadata/packet/metadata.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	DefaultAddress = "https://metadata.packet.net/"
-	apiVersion     = ""
+	DefaultAddress = "https://metadata.platformequinix.com/"
+	apiVersion     = "metadata"
 	userdataUrl    = "userdata"
 	metadataPath   = "metadata"
 )
@@ -50,7 +50,7 @@ type NetworkData struct {
 	DNS        []net.IP   `json:"dns"`
 }
 
-// Metadata that will be pulled from the https://metadata.packet.net/metadata only. We have the opportunity to add more later.
+// Metadata that will be pulled from the https://metadata.platformequinix.com/metadata only. We have the opportunity to add more later.
 type Metadata struct {
 	Hostname    string      `json:"hostname"`
 	SSHKeys     []string    `json:"ssh_keys"`


### PR DESCRIPTION
# adjust packet metadata url and apiVersion for new equinix api

The equinix metadata API changed since they acquired packet, causing issues during boot.

## How to use

* build 
* run on equinix
To test an out of stream change on equinix, you'll have to start a machine using ipxe boot, as equinix only allows stable and beta channels

## Testing done

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
- [ ] ensure instance with image completely starts up on equinix

## Notes

Since we're making heavy use of this, we're happy to help testing this out, by ie providing an instance on Equinix for testing
