### PR TITLE
OEM: IONOS Cloud Images

### DIFF
--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -31,6 +31,7 @@ import (
 	"github.com/flatcar/coreos-cloudinit/datasource"
 	"github.com/flatcar/coreos-cloudinit/datasource/configdrive"
 	"github.com/flatcar/coreos-cloudinit/datasource/file"
+	"github.com/flatcar/coreos-cloudinit/datasource/ionoscloud"
 	"github.com/flatcar/coreos-cloudinit/datasource/metadata/cloudsigma"
 	"github.com/flatcar/coreos-cloudinit/datasource/metadata/digitalocean"
 	"github.com/flatcar/coreos-cloudinit/datasource/metadata/ec2"
@@ -66,6 +67,7 @@ var (
 			cloudSigmaMetadataService   bool
 			digitalOceanMetadataService string
 			packetMetadataService       string
+			ionosCloudSeed              string
 			url                         string
 			procCmdLine                 bool
 			vmware                      bool
@@ -96,6 +98,7 @@ func init() {
 	flag.BoolVar(&flags.sources.procCmdLine, "from-proc-cmdline", false, fmt.Sprintf("Parse %s for '%s=<url>', using the cloud-config served by an HTTP GET to <url>", proc_cmdline.ProcCmdlineLocation, proc_cmdline.ProcCmdlineCloudConfigFlag))
 	flag.BoolVar(&flags.sources.vmware, "from-vmware-guestinfo", false, "Read data from VMware guestinfo")
 	flag.StringVar(&flags.sources.ovfEnv, "from-vmware-ovf-env", "", "Read data from OVF Environment")
+	flag.StringVar(&flags.sources.ionosCloudSeed, "from-ionoscloud-seed", "", "Read data from IONOS Cloud injected cloud-init seed files")
 	flag.StringVar(&flags.oem, "oem", "", "Use the settings specific to the provided OEM")
 	flag.StringVar(&flags.convertNetconf, "convert-netconf", "", "Read the network config provided in cloud-drive and translate it from the specified format into networkd unit files")
 	flag.StringVar(&flags.workspace, "workspace", "/var/lib/coreos-cloudinit", "Base directory coreos-cloudinit should use to store data")
@@ -133,6 +136,10 @@ var (
 		"vmware": {
 			"from-vmware-guestinfo": "true",
 			"convert-netconf":       "vmware",
+		},
+		"ionoscloud": {
+			"from-ionoscloud-seed": "/var/lib/cloud/seed/nocloud/",
+			"convert-netconf":      "debian",
 		},
 	}
 )
@@ -178,7 +185,7 @@ func main() {
 
 	dss := getDatasources()
 	if len(dss) == 0 {
-		fmt.Println("Provide at least one of --from-file, --from-configdrive, --from-ec2-metadata, --from-gce-metadata, --from-cloudsigma-metadata, --from-packet-metadata, --from-digitalocean-metadata, --from-vmware-guestinfo, --from-waagent, --from-url or --from-proc-cmdline")
+		fmt.Println("Provide at least one of --from-file, --from-configdrive, --from-ec2-metadata, --from-gce-metadata, --from-cloudsigma-metadata, --from-packet-metadata, --from-digitalocean-metadata, --from-ionoscloud-seed, --from-vmware-guestinfo, --from-waagent, --from-url or --from-proc-cmdline")
 		os.Exit(2)
 	}
 
@@ -368,6 +375,9 @@ func getDatasources() []datasource.Datasource {
 	}
 	if flags.sources.ovfEnv != "" {
 		dss = append(dss, vmware.NewDatasource(flags.sources.ovfEnv))
+	}
+	if flags.sources.ionosCloudSeed != "" {
+		dss = append(dss, ionoscloud.NewDatasource(flags.sources.ionosCloudSeed))
 	}
 	return dss
 }

--- a/datasource/ionoscloud/ionoscloud.go
+++ b/datasource/ionoscloud/ionoscloud.go
@@ -1,0 +1,74 @@
+package ionoscloud
+
+import (
+	"log"
+	"os"
+	"path"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/flatcar/coreos-cloudinit/datasource"
+)
+
+const (
+	networkconfig = "/etc/cloud/cloud.cfg.d/99_custom_networking.cfg"
+)
+
+type ionoscloud struct {
+	seed     string
+	readFile func(filename string) ([]byte, error)
+}
+
+func NewDatasource(seed string) *ionoscloud {
+	return &ionoscloud{seed, os.ReadFile}
+}
+
+func (ic *ionoscloud) IsAvailable() bool {
+	_, err := os.Stat(ic.seed)
+	return !os.IsNotExist(err)
+}
+
+func (ic *ionoscloud) AvailabilityChanges() bool {
+	return true
+}
+
+func (ic *ionoscloud) ConfigRoot() string {
+	return ic.seed
+}
+
+func (ic *ionoscloud) FetchMetadata() (metadata datasource.Metadata, err error) {
+	var data []byte
+	var m struct {
+		DSMode        string            `json:"dsmode"`
+		SSHPublicKeys map[string]string `json:"public_keys"`
+	}
+
+	if data, err = ic.tryReadFile(path.Join(ic.seed, "meta-data")); err != nil || len(data) == 0 {
+		return
+	}
+	if err = yaml.Unmarshal([]byte(data), &m); err != nil {
+		return
+	}
+
+	metadata.SSHPublicKeys = m.SSHPublicKeys
+	metadata.NetworkConfig, _ = ic.tryReadFile(networkconfig)
+
+	return
+}
+
+func (ic *ionoscloud) FetchUserdata() ([]byte, error) {
+	return ic.tryReadFile(path.Join(ic.seed, "user-data"))
+}
+
+func (ic *ionoscloud) Type() string {
+	return "ionoscloud"
+}
+
+func (ic *ionoscloud) tryReadFile(filename string) ([]byte, error) {
+	log.Printf("Attempting to read from %q\n", filename)
+	data, err := os.ReadFile(filename)
+	if os.IsNotExist(err) {
+		err = nil
+	}
+	return data, err
+}

--- a/units/user-configdrive.service
+++ b/units/user-configdrive.service
@@ -16,10 +16,12 @@ Before=user-config.target
 After=enable-oem-cloudinit.service oem-cloudinit.service
 
 # Skip on clouds that are covered by flatcar/init:systemd/system/oem-cloudinit.service
-ConditionKernelCommandLine=!flatcar.oem.id=digitalocean
 ConditionKernelCommandLine=!coreos.oem.id=digitalocean
+ConditionKernelCommandLine=!flatcar.oem.id=digitalocean
 ConditionKernelCommandLine=!coreos.oem.id=openstack
 ConditionKernelCommandLine=!flatcar.oem.id=openstack
+ConditionKernelCommandLine=!coreos.oem.id=ionoscloud
+ConditionKernelCommandLine=!flatcar.oem.id=ionoscloud
 [Service]
 Type=oneshot
 ExecCondition=/usr/bin/bash -c "if [ -f '/etc/.ignition-result.json' ] && /usr/bin/jq -e '.userConfigProvided == true' /etc/.ignition-result.json; then exit 1; fi"


### PR DESCRIPTION
# Adds IONOS Cloud custom provider

This aims to keep supporting basic Cloud-Init functionality with Flatcar by introducing the IONOS Cloud provider. As the IONOS Cloud was built on top of the idea of cloud-init all of our utilities and customers use it. Therefore we want to have basic feature support to not force everyone to switch to ignition

## How to use

Use the IONOS Cloud Flatcar image to create a VM and inject Cloud-Init User Data:

https://docs.ionos.com/cloud/storage-and-backup/block-storage/images-snapshots/boot-cloud-init

Use the `#cloud-config` directive!

## Testing done

Used the Image built from https://github.com/flatcar/scripts/pull/2389 and inject a basic cloud-config script:

```yaml
#cloud-config

write_files:
  - path: /hello
    content: |
        world!
```

And checked if the file exists after the first boot.


## PR Requirements

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
