### PR TITLE
chore(metadata/gcp): truncate too long hostnames on gcp

### DIFF
--- a/datasource/metadata/gce/metadata.go
+++ b/datasource/metadata/gce/metadata.go
@@ -16,8 +16,10 @@ package gce
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/flatcar/coreos-cloudinit/datasource"
 	"github.com/flatcar/coreos-cloudinit/datasource/metadata"
@@ -49,6 +51,15 @@ func (ms metadataService) FetchMetadata() (datasource.Metadata, error) {
 	hostname, err := ms.fetchString("hostname")
 	if err != nil {
 		return datasource.Metadata{}, err
+	}
+
+	if len(hostname) > 63 {
+		log.Printf("Hostname too long. Truncating hostname %s to %s", hostname, strings.Split(hostname, ".")[0])
+		hostname = strings.Split(hostname, ".")[0]
+		if len(hostname) > 63 {
+			log.Printf("Hostname still too long. Truncating hostname %s further to 63 bytes (%s)", hostname, hostname[:63])
+			hostname = hostname[:63]
+		}
 	}
 
 	return datasource.Metadata{


### PR DESCRIPTION
# truncate too long hostnames on gcp

Long hostnames can have unexpected consequences and this makes the truncation behavior explicit

## How to use

A new node on GCP that uses cloud init and has an overly long host name. 

Technically the second case should never happen, because GCP is attempting to block direct instance names longer than 63 chars, but rather safe than sorry.

## Testing done

Test added for
* truncate on first `.`
* truncate at 63 chars if segment before first `.` is still too long

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

