### PR TITLE
fix(cloud-init): truncate all hostnames on first `.`

### DIFF
--- a/changelog/enhancement/2025-04-03-sanitize-hostname.md
+++ b/changelog/enhancement/2025-04-03-sanitize-hostname.md
@@ -1,0 +1,2 @@
+* Always truncate hostnames on the first occurrence of `.`
+* Ensure hostnames never exceeds 63 characters, regardless of the metadata provider

--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -286,13 +286,14 @@ func determineHostname(md datasource.Metadata, udata *initialize.UserData) strin
 			hostname = udataHostname
 		}
 	}
+	// Always truncate hostnames to everything before the first `.`
+	hostname = strings.Split(hostname, ".")[0]
+
+	// Truncate after 63 characters if the hostname exceeds that
 	if len(hostname) > 63 {
-		log.Printf("Hostname too long. Truncating hostname %s to %s", hostname, strings.Split(hostname, ".")[0])
-		hostname = strings.Split(hostname, ".")[0]
-		if len(hostname) > 63 {
-			log.Printf("Hostname still too long. Truncating hostname %s further to 63 bytes (%s)", hostname, hostname[:63])
-			hostname = hostname[:63]
-		}
+		log.Printf("Hostname too long. Truncating hostname %s to 63 bytes (%s)", hostname, hostname[:63])
+		hostname = hostname[:63]
+
 	}
 	return hostname
 }

--- a/coreos-cloudinit_test.go
+++ b/coreos-cloudinit_test.go
@@ -111,6 +111,25 @@ func TestDetermineHostname(t *testing.T) {
 				PublicIPv6:    net.ParseIP("5.6.7.8"),
 				PrivateIPv4:   net.ParseIP("1.2.3.4"),
 				PrivateIPv6:   net.ParseIP("5.6.7.8"),
+				Hostname:      "regular-name.domain",
+				SSHPublicKeys: map[string]string{"my": "key"},
+				NetworkConfig: net.Interface{
+					Index:        0,
+					MTU:          0,
+					Name:         "some-interface",
+					HardwareAddr: nil,
+					Flags:        0,
+				},
+			},
+			uData:  nil,
+			expect: "regular-name",
+		},
+		{
+			metaData: datasource.Metadata{
+				PublicIPv4:    net.ParseIP("1.2.3.4"),
+				PublicIPv6:    net.ParseIP("5.6.7.8"),
+				PrivateIPv4:   net.ParseIP("1.2.3.4"),
+				PrivateIPv6:   net.ParseIP("5.6.7.8"),
 				Hostname:      "this-hostname-is-larger-than-sixty-three-characters-long-and.will.be.truncated.locale",
 				SSHPublicKeys: map[string]string{"my": "key"},
 				NetworkConfig: net.Interface{


### PR DESCRIPTION
#  truncate all hostnames on first `.`

This ensures consistent behaviour and only if the hostname still exceeds the character limit, it gets truncated further

## How to use

for any hostname, the domain will be cut

## Testing done

the extra test case covers a host name with a domain not exceeding the character limit. Regardless of that it is still truncated to the string before the first `.`

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

