### PR TITLE
fix: update branch references from flatcar-master to main

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ "flatcar-master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "flatcar-master" ]
+    branches: [ "main" ]
 
 jobs:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ The project currently uses the general CoreOS email list and IRC channel:
 
 This is a rough outline of what a contributor's workflow looks like:
 
-- Create a topic branch from where you want to base your work (usually master).
+- Create a topic branch from where you want to base your work (usually main).
 - Make commits of logical units.
 - Make sure your commit messages are in the proper format (see below).
 - Push your changes to a topic branch in your fork of the repository.


### PR DESCRIPTION
This pull request updates references to the default branch name from `flatcar-master` and `master` to `main` across the project configuration and documentation.

Branch name updates:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL5-R7): Changed branch references in the `push` and `pull_request` triggers from `flatcar-master` to `main`.
* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L31-R31): Updated the contributor workflow instructions to use `main` instead of `master` as the base branch for creating topic branches.


Part of: https://github.com/flatcar/Flatcar/issues/1714